### PR TITLE
CardDetail コンポーネントに割引率の表示を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "color": "^4.2.3",
     "next": "12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
@@ -28,6 +29,7 @@
     "@storybook/react": "^6.4.14",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
+    "@types/color": "^3.0.3",
     "@types/node": "17.0.21",
     "@types/react": "17.0.39",
     "@types/styled-components": "^5.1.23",

--- a/src/components/organisms/Cards/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/Cards/CardDetail/CardDetail.tsx
@@ -11,6 +11,7 @@ import {
 } from 'src/styles/Tokens';
 import { Tags } from 'src/components/organisms/Tags';
 import Color from 'color';
+import { discountPercentage } from 'src/utils/Price';
 
 export type CardDetailProps = {
   itemId: string;
@@ -91,8 +92,7 @@ export const CardDetail: VFC<CardDetailProps> = ({ itemId }) => {
   const item = useItem({ itemId });
   if (item === undefined) return <div>loading</div>;
 
-  const percentage =
-    (item.price.discount_amount / item.price.original_price) * 100;
+  const percentage = discountPercentage(item.price);
 
   return (
     <CardWrapper>

--- a/src/components/organisms/Cards/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/Cards/CardDetail/CardDetail.tsx
@@ -97,7 +97,7 @@ export const CardDetail: VFC<CardDetailProps> = ({ itemId }) => {
           src={item.thumbnail}
           alt={`${item.name}のサムネイル画像`}
         />
-        <SaleLabel>{percentage}%OFF</SaleLabel>
+        {item.price.discounted && <SaleLabel>{percentage}%OFF</SaleLabel>}
       </ImageWrapper>
       <ItemContent>
         <ItemName>{item.name}</ItemName>

--- a/src/components/organisms/Cards/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/Cards/CardDetail/CardDetail.tsx
@@ -3,7 +3,12 @@ import { VFC } from 'react';
 import { PriceDisplay } from 'src/components/atoms/Price/PriceDisplay';
 import { useItem } from 'src/hooks/useShopItem';
 import styled from 'styled-components';
-import { breakpoints, fontSizes, spacingSizes } from 'src/styles/Tokens';
+import {
+  breakpoints,
+  colors,
+  fontSizes,
+  spacingSizes,
+} from 'src/styles/Tokens';
 import { Tags } from 'src/components/organisms/Tags';
 
 export type CardDetailProps = {
@@ -64,9 +69,26 @@ const ImageWrapper = styled.div`
   }
 `;
 
+const SaleLabel = styled.div`
+  text-align: center;
+  color: white;
+  font-size: ${fontSizes.fontSize12};
+  background-color: ${colors.Red};
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  opacity: 0.5;
+  height: 25px;
+  line-height: 25px;
+`;
+
 export const CardDetail: VFC<CardDetailProps> = ({ itemId }) => {
   const item = useItem({ itemId });
   if (item === undefined) return <div>loading</div>;
+
+  const percentage =
+    (item.price.discount_amount / item.price.original_price) * 100;
+
   return (
     <CardWrapper>
       <ImageWrapper>
@@ -75,6 +97,7 @@ export const CardDetail: VFC<CardDetailProps> = ({ itemId }) => {
           src={item.thumbnail}
           alt={`${item.name}のサムネイル画像`}
         />
+        <SaleLabel>{percentage}%OFF</SaleLabel>
       </ImageWrapper>
       <ItemContent>
         <ItemName>{item.name}</ItemName>

--- a/src/components/organisms/Cards/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/Cards/CardDetail/CardDetail.tsx
@@ -97,7 +97,9 @@ export const CardDetail: VFC<CardDetailProps> = ({ itemId }) => {
           src={item.thumbnail}
           alt={`${item.name}のサムネイル画像`}
         />
-        {item.price.discounted && <SaleLabel>{percentage}%OFF</SaleLabel>}
+        {item.price.discounted && (
+          <SaleLabel>{Math.floor(percentage)}%OFF</SaleLabel>
+        )}
       </ImageWrapper>
       <ItemContent>
         <ItemName>{item.name}</ItemName>

--- a/src/components/organisms/Cards/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/Cards/CardDetail/CardDetail.tsx
@@ -102,9 +102,7 @@ export const CardDetail: VFC<CardDetailProps> = ({ itemId }) => {
           src={item.thumbnail}
           alt={`${item.name}のサムネイル画像`}
         />
-        {item.price.discounted && (
-          <SaleLabel>{Math.floor(percentage)}%OFF</SaleLabel>
-        )}
+        {item.price.discounted && <SaleLabel>{percentage}%OFF</SaleLabel>}
       </ImageWrapper>
       <ItemContent>
         <ItemName>{item.name}</ItemName>

--- a/src/components/organisms/Cards/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/Cards/CardDetail/CardDetail.tsx
@@ -80,6 +80,11 @@ const SaleLabel = styled.div`
   opacity: 0.5;
   height: 25px;
   line-height: 25px;
+  @media screen and (min-width: ${breakpoints.pc}) {
+    font-size: ${fontSizes.fontSize20};
+    height: 45px;
+    line-height: 45px;
+  }
 `;
 
 export const CardDetail: VFC<CardDetailProps> = ({ itemId }) => {

--- a/src/components/organisms/Cards/CardDetail/CardDetail.tsx
+++ b/src/components/organisms/Cards/CardDetail/CardDetail.tsx
@@ -10,6 +10,7 @@ import {
   spacingSizes,
 } from 'src/styles/Tokens';
 import { Tags } from 'src/components/organisms/Tags';
+import Color from 'color';
 
 export type CardDetailProps = {
   itemId: string;
@@ -73,11 +74,10 @@ const SaleLabel = styled.div`
   text-align: center;
   color: white;
   font-size: ${fontSizes.fontSize12};
-  background-color: ${colors.Red};
+  background-color: ${Color(colors.Red).alpha(0.5).hexa()};
   position: absolute;
   bottom: 0;
   width: 100%;
-  opacity: 0.5;
   height: 25px;
   line-height: 25px;
   @media screen and (min-width: ${breakpoints.pc}) {

--- a/src/utils/Price.ts
+++ b/src/utils/Price.ts
@@ -1,0 +1,4 @@
+import { Price } from 'src/types/mock-api';
+
+export const discountPercentage = (price: Price) =>
+  (price.discount_amount / price.original_price) * 100;

--- a/src/utils/Price.ts
+++ b/src/utils/Price.ts
@@ -1,4 +1,4 @@
 import { Price } from 'src/types/mock-api';
 
 export const discountPercentage = (price: Price) =>
-  (price.discount_amount / price.original_price) * 100;
+  Math.floor((price.discount_amount / price.original_price) * 100);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3207,7 +3207,7 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/color-convert@^2.0.0":
+"@types/color-convert@*", "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
   integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
@@ -3218,6 +3218,13 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.3.tgz#e6d8d72b7aaef4bb9fe80847c26c7c786191016d"
+  integrity sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==
+  dependencies:
+    "@types/color-convert" "*"
 
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.2.0"
@@ -5048,15 +5055,31 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colors@1.4.0:
   version "1.4.0"
@@ -7569,6 +7592,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -11039,6 +11067,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
   integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## 概要
元値と割引額から計算し、Card(Detail)コンポーネントに割引率を表示しました。

## デザイン

[figma](https://www.figma.com/file/BClrVtjyDTeLBViy7zpMGA/yume-shop?node-id=43%3A763)

## 確認

[storybook](http://localhost:6006/?path=/docs/organisms-carddetail--default)
