### PR TITLE
BreadCrumbコンポーネントを作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@storybook/addon-essentials": "^6.4.19",
     "@storybook/addon-links": "^6.4.14",
     "@storybook/react": "^6.4.14",
+    "@storybook/testing-react": "^1.3.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@types/node": "17.0.21",

--- a/src/components/atoms/Button/LinkButton.stories.tsx
+++ b/src/components/atoms/Button/LinkButton.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { LinkButton, LinkButtonProps } from './LinkButton';
+
+export default {
+  component: LinkButton,
+  title: 'atoms/LinkButton',
+} as Meta;
+
+const Template: Story<LinkButtonProps> = (args) => <LinkButton {...args} />;
+
+export const Default = Template.bind({});
+Default.args = { href: '/', label: 'TOP' };

--- a/src/components/atoms/Button/LinkButton.tsx
+++ b/src/components/atoms/Button/LinkButton.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { VFC } from 'react';
+import {
+  breakpoints,
+  colors,
+  fontSizes,
+  spacingSizes,
+} from 'src/styles/Tokens';
+import styled from 'styled-components';
+
+export type LinkButtonProps = {
+  label: string;
+  href: string;
+};
+
+const Wrapper = styled.div`
+  background: ${colors.White};
+  padding: ${spacingSizes.xs};
+  font-size: ${fontSizes.fontSize12};
+  border-radius: 4px;
+  width: fit-content;
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
+  @media screen and (min-width: ${breakpoints.pc}) {
+    font-size: ${fontSizes.fontSize18};
+    padding: ${spacingSizes.xxs} ${spacingSizes.xs};
+  }
+`;
+
+export const LinkButton: VFC<LinkButtonProps> = ({ label, href }) => (
+  <Wrapper>
+    <Link href={href}>{label}</Link>
+  </Wrapper>
+);

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,0 +1,2 @@
+export { LinkButton } from './LinkButton';
+export type { LinkButtonProps } from './LinkButton';

--- a/src/components/organisms/BreadCrumb/BreadCrumb.stories.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { BreadCrumb, BreadCrumbProps } from './BreadCrumb';
+
+export default {
+  component: BreadCrumb,
+  title: 'organisms/BreadCrumb',
+} as Meta;
+
+const Template: Story<BreadCrumbProps> = (args) => <BreadCrumb {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  links: [
+    { href: '/', label: 'TOP' },
+    { href: '/list', label: 'xxx一覧' },
+  ],
+  current: 'hoge',
+};

--- a/src/components/organisms/BreadCrumb/BreadCrumb.test.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.test.tsx
@@ -8,8 +8,8 @@ const { Default } = composeStories(BreadCrumbStory);
 describe('BreadCrumb', () => {
   it('TOP > xxx一覧 > hoge', () => {
     render(<Default />);
-    expect(screen.getByText('TOP')).toBeInTheDocument();
-    expect(screen.getByText('xxx一覧')).toBeInTheDocument();
+    expect(screen.getByText('TOP').tagName).toBe('A');
+    expect(screen.getByText('xxx一覧').tagName).toBe('A');
     expect(screen.getByText('hoge')).toBeInTheDocument();
   });
 });

--- a/src/components/organisms/BreadCrumb/BreadCrumb.test.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/testing-react';
+
+import * as BreadCrumbStory from './BreadCrumb.stories';
+
+const { Default } = composeStories(BreadCrumbStory);
+
+describe('BreadCrumb', () => {
+  it('TOP > xxx一覧 > hoge', () => {
+    render(<Default />);
+    expect(screen.getByText('TOP')).toBeInTheDocument();
+    expect(screen.getByText('xxx一覧')).toBeInTheDocument();
+    expect(screen.getByText('hoge')).toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/BreadCrumb/BreadCrumb.test.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.test.tsx
@@ -8,8 +8,10 @@ const { Default } = composeStories(BreadCrumbStory);
 describe('BreadCrumb', () => {
   it('TOP > xxx一覧 > hoge', () => {
     render(<Default />);
-    expect(screen.getByText('TOP').tagName).toBe('A');
-    expect(screen.getByText('xxx一覧').tagName).toBe('A');
+    const topHref = screen.getByText('TOP').getAttribute('href');
+    expect(topHref).toBe('/');
+    const listHref = screen.getByText('xxx一覧').getAttribute('href');
+    expect(listHref).toBe('/list');
     expect(screen.getByText('hoge')).toBeInTheDocument();
   });
 });

--- a/src/components/organisms/BreadCrumb/BreadCrumb.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.tsx
@@ -1,0 +1,34 @@
+import { VFC } from 'react';
+import { LinkButton } from 'src/components/atoms/Button';
+import { breakpoints, colors, spacingSizes } from 'src/styles/Tokens';
+import styled from 'styled-components';
+
+export type BreadCrumbProps = {
+  links: { label: string; href: string }[];
+  current: string;
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacingSizes.xs};
+  background-color: ${colors.YumeWhiteGreen2};
+  padding: ${spacingSizes.xxs};
+  box-shadow: inset 0px 1px 4px rgba(0, 0, 0, 0.25);
+  @media screen and (min-width: ${breakpoints.pc}) {
+    gap: ${spacingSizes.sm};
+    padding: ${spacingSizes.sm};
+  }
+`;
+
+export const BreadCrumb: VFC<BreadCrumbProps> = ({ links, current }) => (
+  <Wrapper>
+    {links.map((e) => (
+      <>
+        <LinkButton {...e} />
+        {'>'}
+      </>
+    ))}
+    <span>{current}</span>
+  </Wrapper>
+);

--- a/src/components/organisms/BreadCrumb/BreadCrumb.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.tsx
@@ -1,10 +1,10 @@
 import React, { VFC } from 'react';
-import { LinkButton } from 'src/components/atoms/Button';
+import { LinkButton, LinkButtonProps } from 'src/components/atoms/Button';
 import { breakpoints, colors, spacingSizes } from 'src/styles/Tokens';
 import styled from 'styled-components';
 
 export type BreadCrumbProps = {
-  links: { label: string; href: string }[];
+  links: LinkButtonProps[];
   current: string;
 };
 

--- a/src/components/organisms/BreadCrumb/BreadCrumb.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.tsx
@@ -1,4 +1,4 @@
-import { VFC } from 'react';
+import React, { VFC } from 'react';
 import { LinkButton } from 'src/components/atoms/Button';
 import { breakpoints, colors, spacingSizes } from 'src/styles/Tokens';
 import styled from 'styled-components';
@@ -24,10 +24,10 @@ const Wrapper = styled.div`
 export const BreadCrumb: VFC<BreadCrumbProps> = ({ links, current }) => (
   <Wrapper>
     {links.map((e) => (
-      <>
+      <React.Fragment key={e.href}>
         <LinkButton {...e} />
-        {'>'}
-      </>
+        <span>{'>'}</span>
+      </React.Fragment>
     ))}
     <span>{current}</span>
   </Wrapper>

--- a/src/components/organisms/BreadCrumb/BreadCrumb.tsx
+++ b/src/components/organisms/BreadCrumb/BreadCrumb.tsx
@@ -19,6 +19,16 @@ const Wrapper = styled.div`
     gap: ${spacingSizes.sm};
     padding: ${spacingSizes.sm};
   }
+  & > * {
+    flex-shrink: 0;
+  }
+`;
+
+const CurrentWrapper = styled.span`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  flex-shrink: 1;
 `;
 
 export const BreadCrumb: VFC<BreadCrumbProps> = ({ links, current }) => (
@@ -29,6 +39,6 @@ export const BreadCrumb: VFC<BreadCrumbProps> = ({ links, current }) => (
         <span>{'>'}</span>
       </React.Fragment>
     ))}
-    <span>{current}</span>
+    <CurrentWrapper>{current}</CurrentWrapper>
   </Wrapper>
 );

--- a/src/components/organisms/BreadCrumb/index.tsx
+++ b/src/components/organisms/BreadCrumb/index.tsx
@@ -1,0 +1,2 @@
+export { BreadCrumb } from './BreadCrumb';
+export type { BreadCrumbProps } from './BreadCrumb';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3023,6 +3023,13 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/testing-react@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@storybook/testing-react/-/testing-react-1.3.0.tgz#cd69cae6f48b337ee992520e142c7904cb0bbea7"
+  integrity sha512-TfxzflxwBHSPhetWKuYt239t+1iN8gnnUN8OKo5UGtwwirghKQlApjH23QXW6j8YBqFhmq+yP29Oqf8HgKCFLw==
+  dependencies:
+    "@storybook/csf" "0.0.2--canary.87bc651.0"
+
 "@storybook/theming@6.4.14":
   version "6.4.14"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.4.14.tgz#f034914eb1853a80f588c7c141d47af0595f6d1f"


### PR DESCRIPTION
## 概要

- ボタンの見た目をした`Link`である`LinkButton`コンポーネントを作成
- `BreadCrumb`コンポーネントを作成
- storybookを利用して`BreadCrumb`のテストを作成

## デザイン

https://www.figma.com/file/BClrVtjyDTeLBViy7zpMGA/yume-shop?node-id=43%3A766

## 確認

- [LinkButton](http://localhost:6006/?path=/docs/atoms-linkbutton--default)
- [BreadCrumb](http://localhost:6006/?path=/docs/organisms-breadcrumb--default)